### PR TITLE
Feat/colors overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ using namespace Ntb::Colors;
 Exposes the following utilities for coloring ``std::cout`` output:
 
 ```cpp
-/** Helpers */
 enum Colors : const UInt
+/** Color helpers (optional) */
 const UInt Colors::RESET
 const UInt Colors::BLACK
 const UInt Colors::RED
@@ -128,19 +128,19 @@ const UInt Colors::WHITE
 /**
  * Color marker for foreground/background.
  *
- * @param color The Colors enum member.
+ * @param color The color code.
  * @return String with color marker.
  */
-const String col(const Colors color = Colors::RESET)
+const String col(const UInt color = Colors::RESET)
 /**
  * Color marker for foreground, background and text.
  *
  * @param str The input text.
- * @param color The foreground Colors enum member.
- * @param back The background Colors enum member.
- * @return String with color marker.
+ * @param front The foreground color code.
+ * @param back The background color code.
+ * @return Encapsulated string with color markers.
  */
-const String col(const String str, const Colors color, const Colors back = Colors::RESET)
+const String col(const String str, const UInt front, const UInt back = Colors::RESET)
 ```
 
 > ``Ntb::Colors`` makes use of ``Ntb::Types`` and exposes it.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ Exposes the following utilities for coloring ``std::cout`` output:
 ```cpp
 /** Helpers */
 enum Colors : const UInt
-/** Foreground */
 const UInt Colors::RESET
 const UInt Colors::BLACK
 const UInt Colors::RED
@@ -126,15 +125,6 @@ const UInt Colors::BLUE
 const UInt Colors::MAGENTA
 const UInt Colors::CYAN
 const UInt Colors::WHITE
-/** Background */
-const UInt Colors::BACKBLACK
-const UInt Colors::BACKRED
-const UInt Colors::BACKGREEN
-const UInt Colors::BACKYELLOW
-const UInt Colors::BACKBLUE
-const UInt Colors::BACKMAGENTA
-const UInt Colors::BACKCYAN
-const UInt Colors::BACKWHITE
 /**
  * Color marker for foreground/background.
  *
@@ -209,9 +199,9 @@ clang++ -O1 -std=c++17 -pedantic -Ithirdparty/notixbit
 using namespace Ntb::Colors;
 
 std::cout 
-  << col("Notixbit Creative", Colors::WHITE, Colors::BACKRED) 
+  << col("Notixbit Creative", Colors::WHITE, Colors::RED) 
   << std::endl << std::endl 
-  << col("====POLICE==LINE==DO==NOT==CROSS====", Colors::BLACK, Colors::BACKYELLOW) 
+  << col("====POLICE==LINE==DO==NOT==CROSS====", Colors::BLACK, Colors::YELLOW) 
   << std::endl << std::endl;
 ```
 

--- a/colors/colors.h
+++ b/colors/colors.h
@@ -42,15 +42,7 @@ namespace Colors
     BLUE,
     MAGENTA,
     CYAN,
-    WHITE,
-    BACKBLACK = 40,
-    BACKRED,
-    BACKGREEN,
-    BACKYELLOW,
-    BACKBLUE,
-    BACKMAGENTA,
-    BACKCYAN,
-    BACKWHITE
+    WHITE
   };
 
   /**
@@ -78,7 +70,7 @@ namespace Colors
     const Colors color,
     const Colors back = Colors::RESET)
   {
-    return col(back) + col(color) + str + col();
+    return col(back+10) + col(color) + str + col();
   }
 } // namespace Colors
 } // namespace Ntb

--- a/colors/colors.h
+++ b/colors/colors.h
@@ -70,7 +70,8 @@ namespace Colors
     const Colors color,
     const Colors back = Colors::RESET)
   {
-    return col(back+10) + col(color) + str + col();
+    if (back !== Colors::RESET) back+=10;
+    return col(back) + col(color) + str + col();
   }
 } // namespace Colors
 } // namespace Ntb

--- a/colors/colors.h
+++ b/colors/colors.h
@@ -48,10 +48,10 @@ namespace Colors
   /**
    * Color marker for foreground/background.
    *
-   * @param color The Colors enum member.
+   * @param color The color code.
    * @return String with color marker.
    */
-  inline const String col(const Colors color = Colors::RESET)
+  inline const String col(const UInt color = Colors::RESET)
   {
     const String begin = "\033[";
     const String end = "m";
@@ -61,17 +61,17 @@ namespace Colors
    * Color marker for foreground, background and text.
    *
    * @param str The input text.
-   * @param color The foreground Colors enum member.
-   * @param back The background Colors enum member.
-   * @return String with color marker.
+   * @param front The foreground color code.
+   * @param back The background color code.
+   * @return Encapsulated string with color markers.
    */
   inline auto col(
     const String str,
-    const Colors color,
-    const Colors back = Colors::RESET)
+    const UInt front,
+    UInt back = Colors::RESET)
   {
-    if (back !== Colors::RESET) back+=10;
-    return col(back) + col(color) + str + col();
+    back = (back != Colors::RESET) ? back + 10U : back;
+    return col(back) + col(front) + str + col();
   }
 } // namespace Colors
 } // namespace Ntb


### PR DESCRIPTION
- Removed redundant enum members
The BACK_* color enum members were removed.
You can now specify a background color just
with a regular color enum member.

- From now on Colors:: enum members are optional.
You can directly pass an usigned integer (Ntb::Types::UInt) or use one
of the available Colors:: enum members.